### PR TITLE
x86/multikernel: inherit host timer calibration

### DIFF
--- a/arch/x86/include/asm/multikernel.h
+++ b/arch/x86/include/asm/multikernel.h
@@ -10,6 +10,8 @@
 
 #ifndef __ASSEMBLY__
 
+#include <linux/build_bug.h>
+#include <linux/stddef.h>
 #include <linux/types.h>
 #include <linux/cpumask.h>
 #include <linux/sizes.h>
@@ -54,7 +56,7 @@ static inline int arch_cpu_from_physical_id(u64 phys_id)
  * from a page written by the host while running on CPUs parked by (possibly
  * differently built) spawn kernels.
  *
- * The fields fall into two classes that must not be mixed up:
+ * The fields fall into three classes that must not be mixed up:
  *
  *  - Anchor fields (self_phys, park_phys, park_cr3, ctrl_phys,
  *    ctrl_size): the context's own identity, written once when the
@@ -62,9 +64,13 @@ static inline int arch_cpu_from_physical_id(u64 phys_id)
  *    CPU on halt or offline, so they must stay valid for the context's
  *    whole lifetime.
  *
- *  - Dispatch fields (everything else): the wake mailbox, rewritten for
- *    every publication and staged into registers by the CPU that claims
- *    it. Reparking gets its own repark_* dispatch fields precisely so a
+ *  - Primary boot data (bp and the calibration values appended after it):
+ *    written before the boot CPU is released and consumed while that kernel
+ *    initializes. Secondary and repark publications do not rewrite it.
+ *
+ *  - Dispatch fields (the remaining fixed-size fields): the wake mailbox,
+ *    rewritten for every publication and staged into registers by the CPU
+ *    that claims it. Reparking gets its own repark_* dispatch fields so a
  *    repark publication never overwrites the anchor: the two used to
  *    share fields, and a repark left the anchor pointing at another
  *    kernel's park area, which triple-faulted the next halt.
@@ -91,9 +97,19 @@ struct mk_spawn_context {
 	u32 flags;			/* MK_SPAWN_F_* flags */
 	u32 ready;			/* Signal flag */
 	u32 reserved;			/* Padding for alignment */
-	/* Variable-size struct last - size depends on kernel config */
+	/* Keep all existing context offsets unchanged. */
 	struct boot_params bp;		/* Standard x86 boot params */
+	/* Optional boot data belongs after boot_params, in the zeroed tail. */
+	unsigned long boot_lps;		/* Host delay loops per second */
+	unsigned long boot_cpu_khz;	/* Host CPU frequency calibration */
+	unsigned long boot_tsc_khz;	/* Host TSC frequency calibration */
+	unsigned long boot_apic_hz;	/* Host local APIC timer frequency */
 } __aligned(PAGE_SIZE);
+
+static_assert(offsetof(struct mk_spawn_context, bp) == 144);
+static_assert(offsetof(struct mk_spawn_context, boot_lps) ==
+	      144 + sizeof(struct boot_params));
+static_assert(sizeof(struct mk_spawn_context) == 2 * PAGE_SIZE);
 
 /* Pool park loop code, copied by the host into per-instance park pages */
 extern char mk_pool_park_start[];

--- a/arch/x86/kernel/platform-quirks.c
+++ b/arch/x86/kernel/platform-quirks.c
@@ -14,8 +14,10 @@
 #include <asm/e820/api.h>
 #include <asm/apic.h>
 #include <asm/apicdef.h>
+#include <linux/cpufeature.h>
 #include <asm/mpspec.h>
 #include <asm/numa.h>
+#include <asm/page.h>
 #include <linux/pgtable.h>
 #include <asm/pgtable.h>
 #include <asm/pgtable_64_types.h>
@@ -28,6 +30,35 @@ extern pmd_t *populate_extra_pmd(unsigned long vaddr);
 extern unsigned long orig_boot_params;
 
 #ifdef CONFIG_MULTIKERNEL
+static unsigned long multikernel_cpu_khz;
+static unsigned long multikernel_tsc_khz;
+
+static unsigned long multikernel_calibrate_cpu(void)
+{
+	return multikernel_cpu_khz;
+}
+
+static unsigned long multikernel_calibrate_tsc(void)
+{
+	return multikernel_tsc_khz;
+}
+
+static void __init multikernel_setup_calibration(void)
+{
+	phys_addr_t ctx_phys = orig_boot_params -
+		offsetof(struct mk_spawn_context, bp);
+	struct mk_spawn_context *ctx = __va(ctx_phys);
+
+	if (ctx->self_phys != ctx_phys || !ctx->boot_tsc_khz)
+		return;
+
+	multikernel_tsc_khz = ctx->boot_tsc_khz;
+	multikernel_cpu_khz = ctx->boot_cpu_khz ?: ctx->boot_tsc_khz;
+	x86_platform.calibrate_cpu = multikernel_calibrate_cpu;
+	x86_platform.calibrate_tsc = multikernel_calibrate_tsc;
+	setup_force_cpu_cap(X86_FEATURE_TSC_KNOWN_FREQ);
+}
+
 /*
  * Custom wakeup for multikernel spawn kernels.
  * Uses shared spawn table instead of realmode trampoline.
@@ -105,6 +136,10 @@ static void __init multikernel_parse_smp_config(void)
 	 */
 	apic_update_callback(wakeup_secondary_cpu_64, multikernel_wakeup_cpu);
 }
+#else
+static inline void multikernel_setup_calibration(void)
+{
+}
 #endif /* CONFIG_MULTIKERNEL */
 
 void __init x86_early_init_platform_quirks(void)
@@ -135,6 +170,7 @@ void __init x86_early_init_platform_quirks(void)
 		x86_platform.legacy.i8042 = X86_LEGACY_I8042_PLATFORM_ABSENT;
 		break;
 	case X86_SUBARCH_MULTIKERNEL:
+		multikernel_setup_calibration();
 		x86_platform.legacy.devices.pnpbios = 0;
 		x86_platform.legacy.i8042 = X86_LEGACY_I8042_PLATFORM_ABSENT;
 		x86_platform.legacy.rtc = 0;
@@ -175,7 +211,9 @@ void __init x86_early_init_platform_quirks(void)
 		 * the PIT - which belongs to the host - and then request
 		 * legacy IRQ0, which can never reach an instance CPU that
 		 * has neither a PIC nor an IO-APIC. Ticks come from the
-		 * local APIC timer via setup_percpu_clockev() instead.
+		 * local APIC timer initialized by setup_percpu_clockev().
+		 * Keeping global_clock_event unset bypasses LAPIC timer
+		 * verification, whose fallback path requires legacy IRQ0.
 		 */
 		x86_init.timers.timer_init = x86_init_noop;
 		x86_init.timers.wallclock_init = x86_init_noop;

--- a/arch/x86/multikernel/spawn.c
+++ b/arch/x86/multikernel/spawn.c
@@ -21,6 +21,8 @@
 #include <linux/kernel.h>
 #include <linux/compiler.h>
 #include <linux/iopoll.h>
+#include <linux/delay.h>
+#include <linux/jiffies.h>
 #include <linux/smp.h>
 #include <linux/cpu.h>
 #include <linux/mm.h>
@@ -44,6 +46,7 @@
 #include <asm/irqflags.h>
 #include <asm/processor-flags.h>
 #include <asm/processor.h>
+#include <asm/tsc.h>
 #include <asm/apic.h>
 #include <asm/bootparam.h>
 #include <asm/reboot.h>
@@ -447,6 +450,14 @@ int mk_arch_spawn_instance(struct kimage *image, struct mk_instance *instance,
 			     (unsigned long)instance->trampoline_va,
 			     virt_to_phys(instance->trampoline_va),
 			     virt_to_phys(instance->park_va));
+	instance->spawn_ctx->boot_lps = cpu_data(cpu).loops_per_jiffy;
+	if (!instance->spawn_ctx->boot_lps)
+		instance->spawn_ctx->boot_lps = loops_per_jiffy;
+	instance->spawn_ctx->boot_lps *= HZ;
+	instance->spawn_ctx->boot_cpu_khz = cpu_khz;
+	instance->spawn_ctx->boot_tsc_khz = tsc_khz;
+	instance->spawn_ctx->boot_apic_hz =
+		(unsigned long)lapic_timer_period * HZ;
 
 	return mk_spawn_cpu(instance, cpu, instance->spawn_ctx);
 }
@@ -705,6 +716,17 @@ void mk_init_boot_context(phys_addr_t ctx_phys)
 	}
 
 	mk_boot_context = ctx;
+	/*
+	 * A spawn kernel cannot calibrate against legacy timers because they
+	 * belong to the host. Reuse the selected physical CPU's delay and local
+	 * APIC timer calibration, while keeping explicit command-line values
+	 * authoritative.
+	 */
+	if (!preset_lpj && ctx->boot_lps)
+		preset_lpj = DIV_ROUND_CLOSEST_ULL(ctx->boot_lps, HZ);
+	if (!lapic_timer_period && ctx->boot_apic_hz)
+		lapic_timer_period =
+			DIV_ROUND_CLOSEST_ULL(ctx->boot_apic_hz, HZ);
 
 	/*
 	 * The host's control area (this context, the trampoline and park


### PR DESCRIPTION
## Summary

Spawned x86 kernels cannot safely repeat timer calibration while the primary kernel owns the legacy PIT, PIC, and I/O APIC resources used by those probes.

This commit appends optional calibration fields to the spawn context and records the primary kernel's delay-loop, CPU, TSC, and local APIC timer measurements when preparing a spawned kernel. The spawned kernel reuses those measurements when explicit command-line overrides are absent.

Existing context offsets remain unchanged. The appended fields are zero-initialized, so unavailable measurements retain the existing fallback behavior, while explicit overrides remain authoritative.

## Validation

- strict checkpatch with no errors, warnings, or checks
- focused `platform-quirks.o` and Multikernel spawn object builds
- full `CONFIG_MULTIKERNEL=y` kernel build
- full `CONFIG_MULTIKERNEL=n` `vmlinux` build
- source and model checks for offset preservation, zero-value fallback, explicit overrides, and inherited calibration
- two sequential QEMU integration passes, each completing all 83 required markers
